### PR TITLE
Include template file in python package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
 python_requires = >= 3.9
 
 [options.package_data]
-* = *.yaml, *.json, *.html, *.md
+* = *.yaml, *.json, *.html, *.md, *.jinja
 
 [options.entry_points]
 # Please adapt to package name:


### PR DESCRIPTION
Adds all *.jinja files to package_data option in `setup.cfg`. 

Only then, the template file referenced by the `gdevutil markdown` command is available when installed as regular module via pip.